### PR TITLE
Handle empty fish_key_bindings

### DIFF
--- a/conf.d/autopair.fish
+++ b/conf.d/autopair.fish
@@ -1,4 +1,4 @@
-test -z "$fish_key_bindings" && test
+test -z "$fish_key_bindings" && exit
 
 set --global autopair_left "(" "[" "{" '"' "'"
 set --global autopair_right ")" "]" "}" '"' "'"

--- a/conf.d/autopair.fish
+++ b/conf.d/autopair.fish
@@ -1,8 +1,9 @@
+test -z "$fish_key_bindings" && test
+
 set --global autopair_left "(" "[" "{" '"' "'"
 set --global autopair_right ")" "]" "}" '"' "'"
 set --global autopair_pairs "()" "[]" "{}" '""' "''"
 
-test -z "$fish_key_bindings" && set -l fish_key_bindings fish_default_key_bindings
 test $fish_key_bindings = fish_default_key_bindings \
     && set --local mode default \
     || set --local mode insert

--- a/conf.d/autopair.fish
+++ b/conf.d/autopair.fish
@@ -2,7 +2,7 @@ set --global autopair_left "(" "[" "{" '"' "'"
 set --global autopair_right ")" "]" "}" '"' "'"
 set --global autopair_pairs "()" "[]" "{}" '""' "''"
 
-test $fish_key_bindings = fish_default_key_bindings \
+test "$fish_key_bindings" = fish_default_key_bindings \
     && set --local mode default \
     || set --local mode insert
 

--- a/conf.d/autopair.fish
+++ b/conf.d/autopair.fish
@@ -2,7 +2,8 @@ set --global autopair_left "(" "[" "{" '"' "'"
 set --global autopair_right ")" "]" "}" '"' "'"
 set --global autopair_pairs "()" "[]" "{}" '""' "''"
 
-test "$fish_key_bindings" = fish_default_key_bindings \
+test -z "$fish_key_bindings" && set -l fish_key_bindings fish_default_key_bindings
+test $fish_key_bindings = fish_default_key_bindings \
     && set --local mode default \
     || set --local mode insert
 


### PR DESCRIPTION
This change doesn't make any difference most of the time, but it solves an issue when Fish has been just installed, and `fish_key_bindings` is not defined.

In my use case, I want to install autopair.fish in VM's startup script with `fish -c "fisher install jorgebucaran/autopair.fish"`, which yields an error:

![image](https://user-images.githubusercontent.com/44045911/102678398-20497a00-41e3-11eb-8dfd-525af2b754d0.png)

This error doesn't really affect anything, but it would be nice if there isn't any at all.