### PR TITLE
Make Tab completion and backspace command configurable

### DIFF
--- a/functions/_autopair_backspace.fish
+++ b/functions/_autopair_backspace.fish
@@ -5,5 +5,9 @@ function _autopair_backspace
     test $index -ge 1 &&
         contains -- (string sub --start=$index --length=2 -- "$buffer") $autopair_pairs &&
         commandline --function delete-char
-    commandline --function backward-delete-char
+    if set --query autopair_backspace_command[1]; and functions --query $autopair_backspace_command
+        $autopair_backspace_command
+    else
+        commandline --function backward-delete-char
+    end
 end

--- a/functions/_autopair_backspace.fish
+++ b/functions/_autopair_backspace.fish
@@ -5,7 +5,7 @@ function _autopair_backspace
     test $index -ge 1 &&
         contains -- (string sub --start=$index --length=2 -- "$buffer") $autopair_pairs &&
         commandline --function delete-char
-    if set --query autopair_backspace_command[1]; and functions --query $autopair_backspace_command
+    if set --query autopair_backspace_command[1]; and functions --query $autopair_backspace_command[1]
         $autopair_backspace_command
     else
         commandline --function backward-delete-char

--- a/functions/_autopair_tab.fish
+++ b/functions/_autopair_tab.fish
@@ -3,5 +3,9 @@ function _autopair_tab
 
     string match --quiet --regex -- '\$[^\s]*"$' (commandline --current-token) &&
         commandline --function end-of-line --function backward-delete-char
-    commandline --function complete
+    if set --query autopair_complete_command[1]; and functions --query $autopair_complete_command
+        $autopair_complete_command
+    else
+        commandline --function complete
+    end
 end

--- a/functions/_autopair_tab.fish
+++ b/functions/_autopair_tab.fish
@@ -3,7 +3,7 @@ function _autopair_tab
 
     string match --quiet --regex -- '\$[^\s]*"$' (commandline --current-token) &&
         commandline --function end-of-line --function backward-delete-char
-    if set --query autopair_complete_command[1]; and functions --query $autopair_complete_command
+    if set --query autopair_complete_command[1]; and functions --query $autopair_complete_command[1]
         $autopair_complete_command
     else
         commandline --function complete


### PR DESCRIPTION
Stumbled [this discussion](https://github.com/fish-shell/fish-shell/discussions/12250) and thought I'd create a quick PR

## Note about AI usage
I have little experience with fish plugins, so I had Claude explain some things to me. The change itself was created without AI

## Summary

Adds `autopair_complete_command` variable. When set to a valid function name, `_autopair_tab` calls that function instead of the default `commandline --function complete`. 
This allows composing autopair with other Tab-based plugins like [fifc](https://github.com/gazorby/fifc).

### Usage

```fish
set -g autopair_complete_command _fifc
```

When unset, behavior is unchanged.

### Motivation

Autopair's `--on-variable fish_key_bindings` handler re-applies all its bindings (including Tab) whenever `fish_key_bindings` changes. This means other plugins that bind Tab (like fifc) always get overwritten — autopair's Tab binding wins regardless of plugin load order.

Rather than changing the binding mechanism, this PR lets `_autopair_tab` delegate the actual completion to another function. Autopair still handles its pre-processing (paging mode, variable expansion) and still owns the Tab binding, but the completion step is pluggable.

**See also**: https://github.com/fish-shell/fish-shell/discussions/12250